### PR TITLE
Fix pip.req not found error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from pip.req import parse_requirements
-from setuptools import setup, find_packages
 
 def install():
     required = []

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from pip.req import parse_requirements
+from setuptools import setup, find_packages
 
 def install():
     required = []


### PR DESCRIPTION
requirement parsing을 수동으로 하는데 pip.req 패키지(pip 10.0.0 이후부터 제거된 것으로 보입니다.)를 참조하기 때문에 pip install이나 setup.py를 수동으로 이용하는 데 지장이 있습니다

이에 pip.req 패키지 참조를 제거할 것을 제안합니다.